### PR TITLE
Add Chrome Web Store CD and v1.0.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish Chrome Web Store Extension
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build_and_publish:
+    name: Build & Publish Chrome Web Store Extension
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 14
+    - name: Build & Create extension.zip
+      run: |
+        npm ci
+        npm run create-extension-zip
+    - name: Upload & Publish
+      uses: mnao305/chrome-extension-upload@2.2.0
+      with:
+        file-path: extension.zip
+        extension-id: hogefuga(extension id)
+        client-id: ${{ secrets.CLIENT_ID }}
+        refresh-token: ${{ secrets.REFRESH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: 14
+        node-version: 12
     - name: Build & Create extension.zip
       run: |
         npm ci
@@ -22,6 +22,6 @@ jobs:
       uses: mnao305/chrome-extension-upload@2.2.0
       with:
         file-path: extension.zip
-        extension-id: hogefuga(extension id)
+        extension-id: elloafhmffcedcmbdepancjijjccmail
         client-id: ${{ secrets.CLIENT_ID }}
         refresh-token: ${{ secrets.REFRESH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,3 @@ If not, it should be easily adaptable in `main.ts`.
 To get started:
 - `npm install`
 - `npm run build` (also configured as a VS Code build task)
-
-## TODO
-- Update Chrome Web Store icon with `store-icon.png`
-- Add extension web store page to this readme

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ not sure if this extension will work with other schools' Workday.
 If not, it should be easily adaptable in `main.ts`.
 
 ## Usage
-1. Install the extension
+1. [Install the extension](https://chrome.google.com/webstore/detail/elloafhmffcedcmbdepancjijjccmail)
 2. Go to [Workday](https://wd5.myworkday.com/wpi/)
 3. Click "Academics"
 4. Click "View My Courses" on the right sidebar under "Planning & Registration"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,3 @@ To get started:
 ## TODO
 - Update Chrome Web Store icon with `store-icon.png`
 - Add extension web store page to this readme
-- https://github.com/marketplace/actions/chrome-extension-upload-publish
-- OR
-- https://github.com/marketplace/actions/chrome-extension-upload-action

--- a/out/manifest.json
+++ b/out/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "Workday Schedule Exporter",
     "description": "Adds the functionality to export a course schedule from Workday",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "author": "Gregory Conrad",
     "icons": {
         "16": "icons/icon16.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workday-schedule-exporter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Adds the functionality to export a course schedule from Workday",
   "main": "index.js",
   "author": "Gregory Conrad",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,10 +1,5 @@
-// This should be a service worker, but:
-// https://bugs.chromium.org/p/chromium/issues/detail?id=1024211
 chrome.webRequest.onCompleted.addListener(async ({ url }) => {
     try {
-        // Commented out because we had to downgrade to manifest v2
-        // const [tab] = await chrome.tabs.query({ active: true, currentWindow: true })
-        // chrome.tabs.sendMessage(tab.id!, url)
         chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
             chrome.tabs.sendMessage(tab.id!, url)
         })


### PR DESCRIPTION
# TODO
- [x] Update Chrome Web Store icon with `store-icon.png`
- [x] Add extension web store page link to `README.md` and to GitHub project page
- [x] Update `extension-id` in `.github/workflows/publish.yml`
- [x] Start from step 9 [here](https://github.com/fregante/chrome-webstore-upload/blob/main/How%20to%20generate%20Google%20API%20keys.md) and update repo secrets